### PR TITLE
Feature/vcx v3 delete credential

### DIFF
--- a/vcx/libvcx/src/utils/libindy/anoncreds.rs
+++ b/vcx/libvcx/src/utils/libindy/anoncreds.rs
@@ -248,6 +248,14 @@ pub fn libindy_prover_store_credential(cred_id: Option<&str>,
         .map_err(VcxError::from)
 }
 
+pub fn libindy_prover_delete_credential(cred_id: &str) -> VcxResult<()>{
+
+    anoncreds::prover_delete_credential(get_wallet_handle(),
+                                        cred_id)
+        .wait()
+        .map_err(VcxError::from)
+}
+
 pub fn libindy_prover_create_master_secret(master_secret_id: &str) -> VcxResult<String> {
     if settings::indy_mocks_enabled() { return Ok(settings::DEFAULT_LINK_SECRET_ALIAS.to_string()); }
 

--- a/vcx/libvcx/src/v3/handlers/issuance/mod.rs
+++ b/vcx/libvcx/src/v3/handlers/issuance/mod.rs
@@ -122,6 +122,10 @@ impl Holder {
         self.holder_sm.get_credential()
     }
 
+    pub fn delete_credential(&self) -> VcxResult<()> {
+        self.holder_sm.delete_credential()
+    }
+
     pub fn get_credential_status(&self) -> VcxResult<u32> {
         Ok(self.holder_sm.credential_status())
     }

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -520,6 +520,9 @@ public abstract class LibVcx {
         /** Retrieve information about a stored credential in user's wallet, including credential id and the credential itself. */
         public int vcx_get_credential(int command_handle, int credential_handle, Callback cb);
 
+        /** Delete a credential from the wallet and release it from memory. */
+        public int vcx_delete_credential(int command_handle, int credential_handle, Callback cb);
+
         /**
          * wallet object
          *

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/credential/CredentialApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/credential/CredentialApi.java
@@ -184,6 +184,31 @@ public class CredentialApi extends VcxJava.API {
         return future;
     }
 
+    private static Callback vcxDeleteCredentialCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
+        public void callback(int command_handle, int err) {
+            logger.debug("callback() called with: command_handle = [" + command_handle + "], err = [" + err + "]");
+            CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(command_handle);
+            if (!checkCallback(future,err)) return;
+            // returning empty string from here because we don't want to complete future with null
+            future.complete("");
+        }
+    };
+
+    public static CompletableFuture<String> deleteCredential(
+            int credentialHandle
+    ) throws VcxException {
+        ParamGuard.notNull(credentialHandle, "credentialHandle");
+        logger.debug("deleteCredential() called with: credentialHandle = [" + credentialHandle + "]");
+        CompletableFuture<String> future = new CompletableFuture<String>();
+        int commandHandle = addFuture(future);
+
+        int result = LibVcx.api.vcx_delete_credential(commandHandle, credentialHandle, vcxDeleteCredentialCB);
+        checkResult(result);
+
+        return future;
+    }
+
     private static Callback vcxCredentialUpdateStateCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int command_handle, int err, int state) {


### PR DESCRIPTION
Developed a new API that deletes a credential from the wallet and in the memory. 
It only takes care of the Aries protocol (V3). 

For now, I implemented the Java wrapper only. 