### PR TITLE
VCX Wallet APIs

### DIFF
--- a/vcx/libvcx/src/api/wallet.rs
+++ b/vcx/libvcx/src/api/wallet.rs
@@ -336,7 +336,7 @@ pub extern fn vcx_wallet_update_record_value(command_handle: CommandHandle,
     error::SUCCESS.code_num
 }
 
-/// Updates the value of a record already in the wallet.
+/// Updates the value of a record tags already in the wallet.
 /// Assumes there is an open wallet and that a type and id pair already exists.
 /// #Params
 ///
@@ -346,7 +346,7 @@ pub extern fn vcx_wallet_update_record_value(command_handle: CommandHandle,
 ///
 /// id: the id ("key") of the record.
 ///
-/// tags: New tags for the record with the associated id and type.
+/// tags_json: New tags for the record with the associated id and type.
 ///
 /// cb: Callback that any errors or a receipt of transfer
 ///
@@ -357,20 +357,33 @@ pub extern fn vcx_wallet_update_record_value(command_handle: CommandHandle,
 pub extern fn vcx_wallet_update_record_tags(command_handle: CommandHandle,
                                             type_: *const c_char,
                                             id: *const c_char,
-                                            tags: *const c_char,
+                                            tags_json: *const c_char,
                                             cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32)>) -> u32 {
     info!("vcx_wallet_update_record_tags >>>");
 
     check_useful_c_str!(type_, VcxErrorKind::InvalidOption);
     check_useful_c_str!(id, VcxErrorKind::InvalidOption);
-    check_useful_c_str!(tags, VcxErrorKind::InvalidOption);
+    check_useful_c_str!(tags_json, VcxErrorKind::InvalidOption);
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
-    trace!("vcx_wallet_update_record_tags(command_handle: {}, type_: {}, id: {}, tags: {})",
-           command_handle, secret!(&type_), secret!(&id), secret!(&tags));
+    trace!("vcx_wallet_update_record_tags(command_handle: {}, type_: {}, id: {}, tags_json: {})",
+           command_handle, secret!(&type_), secret!(&id), secret!(&tags_json));
 
     spawn(move || {
-        cb(command_handle, error::SUCCESS.code_num);
+        match wallet::update_record_tags(&type_, &id, &tags_json) {
+            Ok(()) => {
+                trace!("vcx_wallet_update_record_tags(command_handle: {}, rc: {})",
+                       command_handle, error::SUCCESS.message);
+
+                cb(command_handle, error::SUCCESS.code_num);
+            }
+            Err(x) => {
+                trace!("vcx_wallet_update_record_tags(command_handle: {}, rc: {})",
+                       command_handle, x);
+
+                cb(command_handle, x.into());
+            }
+        };
 
         Ok(())
     });
@@ -388,7 +401,7 @@ pub extern fn vcx_wallet_update_record_tags(command_handle: CommandHandle,
 ///
 /// id: the id ("key") of the record.
 ///
-/// tags: Tags for the record with the associated id and type.
+/// tags_json: Tags for the record with the associated id and type.
 ///
 /// cb: Callback that any errors or a receipt of transfer
 ///
@@ -399,20 +412,34 @@ pub extern fn vcx_wallet_update_record_tags(command_handle: CommandHandle,
 pub extern fn vcx_wallet_add_record_tags(command_handle: CommandHandle,
                                          type_: *const c_char,
                                          id: *const c_char,
-                                         tags: *const c_char,
+                                         tags_json: *const c_char,
                                          cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32)>) -> u32 {
     info!("vcx_wallet_add_record_tags >>>");
 
     check_useful_c_str!(type_, VcxErrorKind::InvalidOption);
     check_useful_c_str!(id, VcxErrorKind::InvalidOption);
-    check_useful_c_str!(tags, VcxErrorKind::InvalidOption);
+    check_useful_c_str!(tags_json, VcxErrorKind::InvalidOption);
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
-    trace!("vcx_wallet_add_record_tags(command_handle: {}, type_: {}, id: {}, tags: {})",
-           command_handle, secret!(&type_), secret!(&id), secret!(&tags));
+    trace!("vcx_wallet_add_record_tags(command_handle: {}, type_: {}, id: {}, tags_json: {})",
+           command_handle, secret!(&type_), secret!(&id), secret!(&tags_json));
 
     spawn(move || {
-        cb(command_handle, error::SUCCESS.code_num);
+        match wallet::add_record_tags(&type_, &id, &tags_json) {
+            Ok(()) => {
+                trace!("vcx_wallet_add_record_tags(command_handle: {}, rc: {})",
+                       command_handle, error::SUCCESS.message);
+
+                cb(command_handle, error::SUCCESS.code_num);
+            }
+            Err(x) => {
+                trace!("vcx_wallet_add_record_tags(command_handle: {}, rc: {})",
+                       command_handle, x);
+
+                cb(command_handle, x.into());
+            }
+        };
+
         Ok(())
     });
 
@@ -429,7 +456,7 @@ pub extern fn vcx_wallet_add_record_tags(command_handle: CommandHandle,
 ///
 /// id: the id ("key") of the record.
 ///
-/// tags: Tags to remove from the record with the associated id and type.
+/// tag_names_json: Tags to remove from the record with the associated id and type.
 ///
 /// cb: Callback that any errors or a receipt of transfer
 ///
@@ -440,20 +467,34 @@ pub extern fn vcx_wallet_add_record_tags(command_handle: CommandHandle,
 pub extern fn vcx_wallet_delete_record_tags(command_handle: CommandHandle,
                                             type_: *const c_char,
                                             id: *const c_char,
-                                            tags: *const c_char,
+                                            tag_names_json: *const c_char,
                                             cb: Option<extern fn(xcommand_handle: CommandHandle, err: u32)>) -> u32 {
     info!("vcx_wallet_delete_record_tags >>>");
 
     check_useful_c_str!(type_, VcxErrorKind::InvalidOption);
     check_useful_c_str!(id, VcxErrorKind::InvalidOption);
-    check_useful_c_str!(tags, VcxErrorKind::InvalidOption);
+    check_useful_c_str!(tag_names_json, VcxErrorKind::InvalidOption);
     check_useful_c_callback!(cb, VcxErrorKind::InvalidOption);
 
-    trace!("vcx_wallet_delete_record_tags(command_handle: {}, type_: {}, id: {}, tags: {})",
-           command_handle, secret!(&type_), secret!(&id), secret!(&tags));
+    trace!("vcx_wallet_delete_record_tags(command_handle: {}, type_: {}, id: {}, tag_names_json: {})",
+           command_handle, secret!(&type_), secret!(&id), secret!(&tag_names_json));
 
     spawn(move || {
-        cb(command_handle, error::SUCCESS.code_num);
+        match wallet::delete_record_tags(&type_, &id, &tag_names_json) {
+            Ok(()) => {
+                trace!("vcx_wallet_delete_record_tags(command_handle: {}, rc: {})",
+                       command_handle, error::SUCCESS.message);
+
+                cb(command_handle, error::SUCCESS.code_num);
+            }
+            Err(x) => {
+                trace!("vcx_wallet_delete_record_tags(command_handle: {}, rc: {})",
+                       command_handle, x);
+
+                cb(command_handle, x.into());
+            }
+        };
+
         Ok(())
     });
 

--- a/vcx/libvcx/src/utils/libindy/wallet.rs
+++ b/vcx/libvcx/src/utils/libindy/wallet.rs
@@ -4,7 +4,7 @@ use indy::{wallet, ErrorCode};
 use settings;
 
 use error::prelude::*;
-use indy::{WalletHandle, INVALID_WALLET_HANDLE};
+use indy::{WalletHandle, SearchHandle, INVALID_WALLET_HANDLE};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WalletRecord {
@@ -210,6 +210,30 @@ pub fn update_record_value(xtype: &str, id: &str, value: &str) -> VcxResult<()> 
     if settings::indy_mocks_enabled() { return Ok(()); }
 
     wallet::update_wallet_record_value(get_wallet_handle(), xtype, id, value)
+        .wait()
+        .map_err(VcxError::from)
+}
+
+pub fn open_search(xtype: &str, query: &str, options: &str) -> VcxResult<SearchHandle> {
+    trace!("open_search >>> xtype: {}, query: {}, options: {}", secret!(&xtype), query, options);
+
+    wallet::open_wallet_search(get_wallet_handle(), xtype, query, options)
+        .wait()
+        .map_err(VcxError::from)
+}
+
+pub fn fetch_next_records(search_handle: SearchHandle, count: usize) -> VcxResult<String> {
+    trace!("fetch_next_records >>> search_handle: {}, count: {}", search_handle, count);
+
+    wallet::fetch_wallet_search_next_records(get_wallet_handle(), search_handle, count)
+        .wait()
+        .map_err(VcxError::from)
+}
+
+pub fn close_search(search_handle: SearchHandle) -> VcxResult<()> {
+    trace!("close_search >>> search_handle: {}", search_handle);
+
+    wallet::close_wallet_search(search_handle)
         .wait()
         .map_err(VcxError::from)
 }

--- a/vcx/libvcx/src/utils/libindy/wallet.rs
+++ b/vcx/libvcx/src/utils/libindy/wallet.rs
@@ -214,6 +214,30 @@ pub fn update_record_value(xtype: &str, id: &str, value: &str) -> VcxResult<()> 
         .map_err(VcxError::from)
 }
 
+pub fn add_record_tags(xtype: &str, id: &str, tags: &str) -> VcxResult<()> {
+    trace!("add_record_tags >>> xtype: {}, id: {}, tags: {:?}", secret!(&xtype), secret!(&id), secret!(&tags));
+
+    wallet::add_wallet_record_tags(get_wallet_handle(), xtype, id, tags)
+        .wait()
+        .map_err(VcxError::from)
+}
+
+pub fn update_record_tags(xtype: &str, id: &str, tags: &str) -> VcxResult<()> {
+    trace!("update_record_tags >>> xtype: {}, id: {}, tags: {}", secret!(&xtype), secret!(&id), secret!(&tags));
+
+    wallet::update_wallet_record_tags(get_wallet_handle(), xtype, id, tags)
+        .wait()
+        .map_err(VcxError::from)
+}
+
+pub fn delete_record_tags(xtype: &str, id: &str, tag_names: &str) -> VcxResult<()> {
+    trace!("delete_record_tags >>> xtype: {}, id: {}, tag_names: {}", secret!(&xtype), secret!(&id), secret!(&tag_names));
+
+    wallet::delete_wallet_record_tags(get_wallet_handle(), xtype, id, tag_names)
+        .wait()
+        .map_err(VcxError::from)
+}
+
 pub fn open_search(xtype: &str, query: &str, options: &str) -> VcxResult<SearchHandle> {
     trace!("open_search >>> xtype: {}, query: {}, options: {}", secret!(&xtype), query, options);
 

--- a/vcx/wrappers/ios/vcx/ConnectMeVcx.h
+++ b/vcx/wrappers/ios/vcx/ConnectMeVcx.h
@@ -165,9 +165,10 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
            completion:(void (^)(NSError *error))completion;
 
 - (void)addRecordWallet:(NSString *)recordType
-            recordId:(NSString *)recordId
-            recordValue:(NSString *) recordValue
-           completion:(void (^)(NSError *error))completion;
+               recordId:(NSString *)recordId
+            recordValue:(NSString *)recordValue
+               tagsJson:(NSString *)tagsJson
+             completion:(void (^)(NSError *error))completion;
 
 - (void)updateRecordWallet:(NSString *)recordType
               withRecordId:(NSString *)recordId
@@ -176,11 +177,39 @@ extern void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_h
 
 - (void)getRecordWallet:(NSString *)recordType
                recordId:(NSString *)recordId
-             completion:(void (^)(NSError *error, NSString *walletValue))completion;
+            optionsJson:(NSString *)optionsJson
+             completion:(void (^)(NSError *error, NSString* walletValue))completion;
 
 - (void)deleteRecordWallet:(NSString *)recordType
             recordId:(NSString *)recordId
            completion:(void (^)(NSError *error))completion;
+
+- (void)addRecordTagsWallet:(NSString *)recordType
+                   recordId:(NSString *)recordId
+                   tagsJson:(NSString *) tagsJson
+                 completion:(void (^)(NSError *error))completion;
+
+- (void)updateRecordTagsWallet:(NSString *)recordType
+                      recordId:(NSString *)recordId
+                      tagsJson:(NSString *) tagsJson
+                    completion:(void (^)(NSError *error))completion;
+
+- (void)deleteRecordTagsWallet:(NSString *)recordType
+                      recordId:(NSString *)recordId
+                  tagNamesJson:(NSString *)tagNamesJson
+                    completion:(void (^)(NSError *error))completion;
+
+- (void)openSearchWallet:(NSString *)recordType
+               queryJson:(NSString *)queryJson
+             optionsJson:(NSString *)optionsJson
+              completion:(void (^)(NSError *error, NSInteger searchHandle))completion;
+
+- (void)searchNextRecordsWallet:(NSInteger)searchHandle
+                          count:(int)count
+                     completion:(void (^)(NSError *error, NSString* records))completion;
+
+- (void)closeSearchWallet:(NSInteger)searchHandle
+               completion:(void (^)(NSError *error))completion;
 
 - (void) proofGetRequests:(NSInteger)connectionHandle
               completion:(void (^)(NSError *error, NSString *requests))completion;

--- a/vcx/wrappers/ios/vcx/ConnectMeVcx.m
+++ b/vcx/wrappers/ios/vcx/ConnectMeVcx.m
@@ -779,15 +779,19 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 
 - (void)addRecordWallet:(NSString *)recordType
                recordId:(NSString *)recordId
-            recordValue:(NSString *) recordValue
+            recordValue:(NSString *)recordValue
+               tagsJson:(NSString *)tagsJson
              completion:(void (^)(NSError *error))completion {
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+   if (!tagsJson.length) tagsJson = @"{}";
+   
    const char * record_type =[recordType cStringUsingEncoding:NSUTF8StringEncoding];
    const char * record_id = [recordId cStringUsingEncoding:NSUTF8StringEncoding];
    const char * record_value =[recordValue cStringUsingEncoding:NSUTF8StringEncoding];
-   const char * record_tag = "{}";
-    ret = vcx_wallet_add_record(handle, record_type, record_id, record_value, record_tag, VcxWrapperCommonCallback);
+   const char * tags_json =[tagsJson cStringUsingEncoding:NSUTF8StringEncoding];
+   
+    ret = vcx_wallet_add_record(handle, record_type, record_id, record_value, tags_json, VcxWrapperCommonCallback);
 
    if( ret != 0 )
    {
@@ -800,14 +804,17 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
 }
 
 - (void)getRecordWallet:(NSString *)recordType
-            recordId:(NSString *)recordId
+               recordId:(NSString *)recordId
+            optionsJson:(NSString *)optionsJson
              completion:(void (^)(NSError *error, NSString* walletValue))completion {
    vcx_error_t ret;
    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    
+   if (!optionsJson.length) optionsJson = @"{}";
    const char * record_type =[recordType cStringUsingEncoding:NSUTF8StringEncoding];
    const char * record_id = [recordId cStringUsingEncoding:NSUTF8StringEncoding];
-   const char * record_tag = "{}";
-    ret = vcx_wallet_get_record(handle, record_type, record_id, record_tag, VcxWrapperCommonStringCallback);
+   const char * options_json = [optionsJson cStringUsingEncoding:NSUTF8StringEncoding];
+    ret = vcx_wallet_get_record(handle, record_type, record_id, options_json, VcxWrapperCommonStringCallback);
 
    if( ret != 0 )
    {
@@ -864,6 +871,133 @@ void VcxWrapperCommonNumberStringCallback(vcx_command_handle_t xcommand_handle,
             completion([NSError errorFromVcxError: ret]);
         });
     }
+}
+
+- (void)addRecordTagsWallet:(NSString *)recordType
+               recordId:(NSString *)recordId
+            tagsJson:(NSString *) tagsJson
+             completion:(void (^)(NSError *error))completion {
+   vcx_error_t ret;
+   vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+   const char * record_type =[recordType cStringUsingEncoding:NSUTF8StringEncoding];
+   const char * record_id = [recordId cStringUsingEncoding:NSUTF8StringEncoding];
+   const char * tags_json =[tagsJson cStringUsingEncoding:NSUTF8StringEncoding];
+    
+    ret = vcx_wallet_add_record_tags(handle, record_type, record_id, tags_json, VcxWrapperCommonCallback);
+
+   if( ret != 0 )
+   {
+       [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+       dispatch_async(dispatch_get_main_queue(), ^{
+           completion([NSError errorFromVcxError: ret]);
+       });
+   }
+}
+
+- (void)updateRecordTagsWallet:(NSString *)recordType
+              recordId:(NSString *)recordId
+           tagsJson:(NSString *) tagsJson
+            completion:(void (^)(NSError *error))completion {
+    vcx_error_t ret;
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    const char * record_type =[recordType cStringUsingEncoding:NSUTF8StringEncoding];
+    const char * record_id = [recordId cStringUsingEncoding:NSUTF8StringEncoding];
+    const char * tags_json =[tagsJson cStringUsingEncoding:NSUTF8StringEncoding];
+
+    ret = vcx_wallet_update_record_tags(handle, record_type, record_id, tags_json, VcxWrapperCommonCallback);
+
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret]);
+        });
+    }
+}
+
+- (void)deleteRecordTagsWallet:(NSString *)recordType
+            recordId:(NSString *)recordId
+            tagNamesJson:(NSString *)tagNamesJson
+           completion:(void (^)(NSError *error))completion {
+   vcx_error_t ret;
+   vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+   const char * record_type =[recordType cStringUsingEncoding:NSUTF8StringEncoding];
+   const char * record_id = [recordId cStringUsingEncoding:NSUTF8StringEncoding];
+   const char * tag_names_json = [tagNamesJson cStringUsingEncoding:NSUTF8StringEncoding];
+    
+   ret = vcx_wallet_delete_record_tags(handle, record_type, record_id, tag_names_json,  VcxWrapperCommonCallback);
+
+   if( ret != 0 )
+   {
+       [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+       dispatch_async(dispatch_get_main_queue(), ^{
+           completion([NSError errorFromVcxError: ret]);
+       });
+   }
+}
+
+- (void)openSearchWallet:(NSString *)recordType
+               queryJson:(NSString *)queryJson
+            optionsJson:(NSString *)optionsJson
+             completion:(void (^)(NSError *error, NSInteger searchHandle))completion {
+   vcx_error_t ret;
+   vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    
+   if (!queryJson.length) queryJson = @"{}";
+   if (!optionsJson.length) optionsJson = @"{}";
+    
+   const char * record_type =[recordType cStringUsingEncoding:NSUTF8StringEncoding];
+   const char * query_json = [queryJson cStringUsingEncoding:NSUTF8StringEncoding];
+   const char * options_json =[optionsJson cStringUsingEncoding:NSUTF8StringEncoding];
+    
+    ret = vcx_wallet_open_search(handle, record_type, query_json, options_json, VcxWrapperCommonHandleCallback);
+
+   if( ret != 0 )
+   {
+       [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+       dispatch_async(dispatch_get_main_queue(), ^{
+           completion([NSError errorFromVcxError: ret], 0);
+       });
+   }
+}
+
+- (void)searchNextRecordsWallet:(NSInteger)searchHandle
+              count:(int)count
+            completion:(void (^)(NSError *error, NSString* records))completion {
+    vcx_error_t ret;
+    vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+
+    ret = vcx_wallet_search_next_records(handle, searchHandle, count, VcxWrapperCommonStringCallback);
+
+    if( ret != 0 )
+    {
+        [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion([NSError errorFromVcxError: ret], nil);
+        });
+    }
+}
+
+- (void)closeSearchWallet:(NSInteger)searchHandle
+           completion:(void (^)(NSError *error))completion {
+   vcx_error_t ret;
+   vcx_command_handle_t handle = [[VcxCallbacks sharedInstance] createCommandHandleFor:completion];
+    
+   ret = vcx_wallet_close_search(handle, searchHandle, VcxWrapperCommonCallback);
+
+   if( ret != 0 )
+   {
+       [[VcxCallbacks sharedInstance] deleteCommandHandleFor: handle];
+
+       dispatch_async(dispatch_get_main_queue(), ^{
+           completion([NSError errorFromVcxError: ret]);
+       });
+   }
 }
 
 - (void)proofGetRequests:(NSInteger)connectionHandle

--- a/vcx/wrappers/ios/vcx/include/libvcx.h
+++ b/vcx/wrappers/ios/vcx/include/libvcx.h
@@ -28,6 +28,7 @@ typedef unsigned int vcx_credentialdef_handle_t;
 typedef unsigned int vcx_connection_handle_t;
 typedef unsigned int vcx_credential_handle_t;
 typedef unsigned int vcx_proof_handle_t;
+typedef unsigned int vcx_search_handle_t;
 typedef unsigned int vcx_command_handle_t;
 typedef unsigned int vcx_bool_t;
 typedef unsigned int vcx_payment_handle_t;
@@ -363,16 +364,35 @@ vcx_error_t vcx_wallet_export(vcx_command_handle_t handle, const char *path, con
 vcx_error_t vcx_wallet_import(vcx_command_handle_t handle, const char *config, void (*cb)(vcx_command_handle_t command_handle, vcx_error_t err));
 
 /** Add a record inside a wallet */
-vcx_error_t vcx_wallet_add_record(vcx_command_handle_t chandle, const char * type_, const char *record_id, const char *record_value, const char *tags_json, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
+vcx_error_t vcx_wallet_add_record(vcx_command_handle_t handle, const char * type_, const char *record_id, const char *record_value, const char *tags_json, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
 
 /** Get a record from wallet */
-vcx_error_t vcx_wallet_get_record(vcx_command_handle_t chandle, const char * type_, const char *record_id, const char *options, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err, const char *record_json));
+vcx_error_t vcx_wallet_get_record(vcx_command_handle_t handle, const char * type_, const char *record_id, const char *options, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err, const char *record_json));
 
 /** Delete a record from wallet */
-vcx_error_t vcx_wallet_delete_record(vcx_command_handle_t chandle, const char * type_, const char *record_id, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
+vcx_error_t vcx_wallet_delete_record(vcx_command_handle_t handle, const char * type_, const char *record_id, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
 
 /** Update a record in wallet if it is already added */
-vcx_error_t vcx_wallet_update_record_value(vcx_command_handle_t chandle, const char *type_, const char *record_id, const char *record_value, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
+vcx_error_t vcx_wallet_update_record_value(vcx_command_handle_t handle, const char *type_, const char *record_id, const char *record_value, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
+
+/** Add record tags to a record */
+vcx_error_t vcx_wallet_add_record_tags(vcx_command_handle_t command_handle, const char * type_, const char *record_id, const char *tags_json, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
+
+/** Update record tags in a record */
+vcx_error_t vcx_wallet_update_record_tags(vcx_command_handle_t command_handle, const char *type_, const char *record_id, const char *tags_json, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
+
+/** Delete record tags from a record */
+vcx_error_t vcx_wallet_delete_record_tags(vcx_command_handle_t command_handle, const char * type_, const char *record_id, const char *tag_names_json, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
+
+/** Opens a wallet search handle */
+vcx_error_t vcx_wallet_open_search(vcx_command_handle_t commond_handle, const char * type_, const char *query_json, const char *options_json, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err, vcx_search_handle_t search_handle));
+
+/** Fetch next records for wallet search */
+vcx_error_t vcx_wallet_search_next_records(vcx_command_handle_t command_handle, vcx_search_handle_t search_handle, int count, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err, const char *records_json));
+
+/** Close a search */
+vcx_error_t vcx_wallet_close_search(vcx_command_handle_t commond_handle, vcx_search_handle_t search_handle, void (*cb)(vcx_command_handle_t xhandle, vcx_error_t err));
+
 
 /**
  * token object

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -533,7 +533,7 @@ public abstract class LibVcx {
         public int vcx_wallet_import(int command_handle, String config, Callback cb);
 
         /** Add a record into wallet */
-        public int vcx_wallet_add_record(int command_handle, String recordType, String recordId, String recordValue, String recordTag, Callback cb);
+        public int vcx_wallet_add_record(int command_handle, String recordType, String recordId, String recordValue, String tagsJson, Callback cb);
 
         /** Delete a record from wallet */
         public int vcx_wallet_delete_record(int command_handle, String recordType, String recordId, Callback cb);
@@ -543,6 +543,15 @@ public abstract class LibVcx {
 
         /** Update a record in wallet */
         public int vcx_wallet_update_record_value(int command_handle, String recordType, String recordId, String recordValue, Callback cb);
+
+        /** Opens a wallet search handle */
+        public int vcx_wallet_open_search(int command_handle, String recordType, String queryJson, String optionsJson, Callback cb);
+
+        /** Fetch next records for wallet search */
+        public int vcx_wallet_search_next_records(int command_handle, int search_handle, int count, Callback cb);
+
+        /** Close a search */
+        public int vcx_wallet_close_search(int command_handle, int search_handle, Callback cb);
 
         /** Set wallet handle manually */
         public int vcx_wallet_set_handle(int handle);

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/LibVcx.java
@@ -544,6 +544,16 @@ public abstract class LibVcx {
         /** Update a record in wallet */
         public int vcx_wallet_update_record_value(int command_handle, String recordType, String recordId, String recordValue, Callback cb);
 
+        /** Add record tags to a record */
+        public int vcx_wallet_add_record_tags(int command_handle, String recordType, String recordId, String tagsJson, Callback cb);
+
+        /** Update record tags in a record */
+        public int vcx_wallet_update_record_tags(int command_handle, String recordType, String recordId, String tagsJson, Callback cb);
+
+        /** Delete record tags from a record */
+        public int vcx_wallet_delete_record_tags(int command_handle, String recordType, String recordId, String tagNamesJson, Callback cb);
+
+
         /** Opens a wallet search handle */
         public int vcx_wallet_open_search(int command_handle, String recordType, String queryJson, String optionsJson, Callback cb);
 
@@ -552,6 +562,7 @@ public abstract class LibVcx {
 
         /** Close a search */
         public int vcx_wallet_close_search(int command_handle, int search_handle, Callback cb);
+
 
         /** Set wallet handle manually */
         public int vcx_wallet_set_handle(int handle);

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/wallet/WalletApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/wallet/WalletApi.java
@@ -287,6 +287,9 @@ public class WalletApi extends VcxJava.API {
         return future;
     }
 
+    /**
+     * Callback used when function returning void completes.
+     */
     private static Callback vcxAddRecordTagsWalletCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err) {
@@ -298,6 +301,20 @@ public class WalletApi extends VcxJava.API {
         }
     };
 
+
+    /**
+     * Add tags to a record already stored in the storage wallet.
+     *
+     * @param recordType Allows to separate different record types collections
+     * @param recordId The id of record
+     * @param tagsJson The record tags used for search and storing meta information as json:
+     *                  {
+     *                      "tagName1": "str", // string tag (will be stored encrypted)
+     *                      "~tagName2": "str", // string tag (will be stored un-encrypted)
+     *                  }
+     * @return A future that resolves no value.
+     * @throws VcxException Thrown if an error occurs when calling the underlying SDK.
+     */
     public static CompletableFuture<Integer> addRecordTagsWallet(
             String recordType,
             String recordId,
@@ -316,6 +333,9 @@ public class WalletApi extends VcxJava.API {
         return future;
     }
 
+    /**
+     * Callback used when function returning void completes.
+     */
     private static Callback vcxUpdateRecordTagsWalletCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err) {
@@ -326,6 +346,19 @@ public class WalletApi extends VcxJava.API {
         }
     };
 
+    /**
+     * Update tags on a record, removing any previous value.
+     *
+     * @param recordType Allows to separate different record types collections
+     * @param recordId The id of record
+     * @param tagsJson The record tags used for search and storing meta information as json:
+     *                  {
+     *                      "tagName1": "str", // string tag (will be stored encrypted)
+     *                      "~tagName2": "str", // string tag (will be stored un-encrypted)
+     *                  }
+     * @return A future that resolves no value.
+     * @throws VcxException Thrown if an error occurs when calling the underlying SDK.
+     */
     public static CompletableFuture<Integer> updateRecordTagsWallet(
             String recordType,
             String recordId,
@@ -344,6 +377,9 @@ public class WalletApi extends VcxJava.API {
         return future;
     }
 
+    /**
+     * Callback used when function returning void completes.
+     */
     private static Callback vcxDeleteRecordTagsWalletCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err) {
@@ -355,6 +391,16 @@ public class WalletApi extends VcxJava.API {
         }
     };
 
+    /**
+     * Delete tags associated with a record
+     *
+     * @param recordType Allows to separate different record types collections
+     * @param recordId The id of record
+     * @param tagNamesJson The list of tag names to remove from the record as json array:
+     *                     ["tagName1", "tagName2", ...]
+     * @return A future that resolves no value.
+     * @throws VcxException Thrown if an error occurs when calling the underlying SDK.
+     */
     public static CompletableFuture<Integer> deleteRecordTagsWallet(
             String recordType,
             String recordId,
@@ -373,6 +419,9 @@ public class WalletApi extends VcxJava.API {
         return future;
     }
 
+    /**
+     * Callback used when function returning integer completes.
+     */
     private static Callback vcxOpenSearchWalletCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err, int searchHandle) {
@@ -384,6 +433,28 @@ public class WalletApi extends VcxJava.API {
         }
     };
 
+    /**
+     * Open a search handle within the storage wallet.
+     *
+     * @param recordType Allows to separate different record types collections
+     * @param queryJson MongoDB style query to wallet record tags:
+     *                    {
+     *                      "tagName": "tagValue",
+     *                      $or: {
+     *                          "tagName2": { $regex: 'pattern' },
+     *                          "tagName3": { $gte: '123' },
+     *                      }
+     *                    }
+     * @param optionsJson {
+     *                      retrieveRecords: (optional, true by default) If false only "counts" will be calculated,
+     *                      retrieveTotalCount: (optional, false by default) Calculate total count,
+     *                      retrieveType: (optional, false by default) Retrieve record type,
+     *                      retrieveValue: (optional, true by default) Retrieve record value,
+     *                      retrieveTags: (optional, false by default) Retrieve record tags,
+     *                    }
+     * @return A future that resolves to WalletSearch instance.
+     * @throws VcxException Thrown if an error occurs when calling the underlying SDK.
+     */
     public static CompletableFuture<Integer> openSearchWallet(
             String recordType,
             String queryJson,
@@ -408,6 +479,9 @@ public class WalletApi extends VcxJava.API {
         return future;
     }
 
+    /**
+     * Callback used when function returning string completes.
+     */
     private static Callback vcxSearchNextRecordsWalletCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err, String recordValue) {
@@ -418,6 +492,23 @@ public class WalletApi extends VcxJava.API {
         }
     };
 
+    /**
+     * Search for next n record from an open search handle
+     *
+     * @param searchHandle The wallet search handle.
+     * @param count Count of records to fetch
+     * @return A future resolving to the wallet records json:
+     * {
+     *      totalCount: int, // present only if retrieveTotalCount set to true
+     *      records: [{ // present only if retrieveRecords set to true
+     *          id: "Some id",
+     *          type: "Some type", // present only if retrieveType set to true
+     *          value: "Some value", // present only if retrieveValue set to true
+     *          tags: "Some tags json", // present only if retrieveTags set to true
+     *      }],
+     * }
+     * @throws VcxException Thrown if an error occurs when calling the underlying SDK.
+     */
     public static CompletableFuture<String> searchNextRecordsWallet(
             int searchHandle,
             int count
@@ -433,6 +524,9 @@ public class WalletApi extends VcxJava.API {
         return future;
     }
 
+    /**
+     * Callback used when function returning void completes.
+     */
     private static Callback vcxCloseSearchWalletCB = new Callback() {
         @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err) {
@@ -444,6 +538,13 @@ public class WalletApi extends VcxJava.API {
         }
     };
 
+    /**
+     * Close a search
+     *
+     * @param searchHandle The wallet search handle.
+     * @return A future resolving to no value.
+     * @throws VcxException Thrown if an error occurs when calling the underlying SDK.
+     */
     public static CompletableFuture<Integer> closeSearchWallet(
             int searchHandle
     ) throws VcxException {

--- a/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/wallet/WalletApi.java
+++ b/vcx/wrappers/java/src/main/java/com/evernym/sdk/vcx/wallet/WalletApi.java
@@ -287,7 +287,94 @@ public class WalletApi extends VcxJava.API {
         return future;
     }
 
+    private static Callback vcxAddRecordTagsWalletCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
+        public void callback(int commandHandle, int err) {
+            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "]");
+            CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
+            if (!checkCallback(future, err)) return;
+            Integer result = commandHandle;
+            future.complete(result);
+        }
+    };
+
+    public static CompletableFuture<Integer> addRecordTagsWallet(
+            String recordType,
+            String recordId,
+            String tagsJson
+    ) throws VcxException {
+        ParamGuard.notNull(recordType, "recordType");
+        ParamGuard.notNull(recordId, "recordId");
+        ParamGuard.notNull(tagsJson, "tagsJson");
+        logger.debug("addRecordTagsWallet() called with: recordType = [" + recordType + "], recordId = [" + recordId + "], tagsJson = [****]");
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        int commandHandle = addFuture(future);
+
+        int result = LibVcx.api.vcx_wallet_add_record_tags(commandHandle, recordType, recordId, tagsJson, vcxAddRecordTagsWalletCB);
+        checkResult(result);
+
+        return future;
+    }
+
+    private static Callback vcxUpdateRecordTagsWalletCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
+        public void callback(int commandHandle, int err) {
+            CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
+            if (!checkCallback(future, err)) return;
+            Integer result = commandHandle;
+            future.complete(result);
+        }
+    };
+
+    public static CompletableFuture<Integer> updateRecordTagsWallet(
+            String recordType,
+            String recordId,
+            String tagsJson
+    ) throws VcxException {
+        ParamGuard.notNull(recordType, "recordType");
+        ParamGuard.notNull(recordId, "recordId");
+        ParamGuard.notNull(tagsJson, "tagsJson");
+        logger.debug("updateRecordTagsWallet() called with: recordType = [" + recordType + "], recordId = [" + recordId + "], tagsJson = [****]");
+        CompletableFuture<Integer> future = new CompletableFuture<Integer>();
+        int commandHandle = addFuture(future);
+
+        int result = LibVcx.api.vcx_wallet_update_record_tags(commandHandle, recordType, recordId, tagsJson, vcxUpdateRecordTagsWalletCB);
+        checkResult(result);
+
+        return future;
+    }
+
+    private static Callback vcxDeleteRecordTagsWalletCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
+        public void callback(int commandHandle, int err) {
+            logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "]");
+            CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
+            if (!checkCallback(future, err)) return;
+            Integer result = commandHandle;
+            future.complete(result);
+        }
+    };
+
+    public static CompletableFuture<Integer> deleteRecordTagsWallet(
+            String recordType,
+            String recordId,
+            String tagNamesJson
+    ) throws VcxException {
+        ParamGuard.notNull(recordType, "recordType");
+        ParamGuard.notNull(recordId, "recordId");
+        ParamGuard.notNull(tagNamesJson, "tagNamesJson");
+        logger.debug("deleteRecordTagsWallet() called with: recordType = [" + recordType + "], recordId = [" + recordId + "], tagsNamesJson = [****]");
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        int commandHandle = addFuture(future);
+
+        int result = LibVcx.api.vcx_wallet_delete_record_tags(commandHandle, recordType, recordId, tagNamesJson, vcxDeleteRecordTagsWalletCB);
+        checkResult(result);
+
+        return future;
+    }
+
     private static Callback vcxOpenSearchWalletCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err, int searchHandle) {
             logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "], searchHandle = [" + searchHandle + "]");
             CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);
@@ -322,6 +409,7 @@ public class WalletApi extends VcxJava.API {
     }
 
     private static Callback vcxSearchNextRecordsWalletCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err, String recordValue) {
             logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "], recordValue = [****]");
             CompletableFuture<String> future = (CompletableFuture<String>) removeFuture(commandHandle);
@@ -346,6 +434,7 @@ public class WalletApi extends VcxJava.API {
     }
 
     private static Callback vcxCloseSearchWalletCB = new Callback() {
+        @SuppressWarnings({"unused", "unchecked"})
         public void callback(int commandHandle, int err) {
             logger.debug("callback() called with: commandHandle = [" + commandHandle + "], err = [" + err + "]");
             CompletableFuture<Integer> future = (CompletableFuture<Integer>) removeFuture(commandHandle);

--- a/vcx/wrappers/java/src/test/java/com/evernym/sdk/vcx/WalletApiTest.java
+++ b/vcx/wrappers/java/src/test/java/com/evernym/sdk/vcx/WalletApiTest.java
@@ -31,14 +31,14 @@ public class WalletApiTest {
     @Test
     @DisplayName("create a record")
     void createRecord() throws VcxException, ExecutionException, InterruptedException {
-        int recordHandle = TestHelper.getResultFromFuture(WalletApi.addRecordWallet(type,id,value));
+        int recordHandle = TestHelper.getResultFromFuture(WalletApi.addRecordWallet(type,id,value, ""));
         assert (recordHandle != 0);
     }
 
     @Test
     @DisplayName("get a record")
     void getRecord() throws VcxException, ExecutionException, InterruptedException {
-        int recordHandle = TestHelper.getResultFromFuture(WalletApi.addRecordWallet(type,id,value));
+        int recordHandle = TestHelper.getResultFromFuture(WalletApi.addRecordWallet(type,id,value, ""));
         String recordValue = TestHelper.getResultFromFuture(WalletApi.getRecordWallet(type,id,""));
         assert (recordValue.contains(value));
     }
@@ -46,7 +46,7 @@ public class WalletApiTest {
     @Test
     @DisplayName("update a record")
     void updateRecord() throws VcxException, ExecutionException, InterruptedException {
-        int recordHandle = TestHelper.getResultFromFuture(WalletApi.addRecordWallet(type,id,value));
+        int recordHandle = TestHelper.getResultFromFuture(WalletApi.addRecordWallet(type,id,value, ""));
         int updatedRecordHandle = TestHelper.getResultFromFuture(WalletApi.updateRecordWallet(type,id,"new"));
         assert (updatedRecordHandle != 0);
     }
@@ -54,7 +54,7 @@ public class WalletApiTest {
     @Test
     @DisplayName("delete a record")
     void deleteRecord() throws VcxException, ExecutionException, InterruptedException {
-        int recordHandle = TestHelper.getResultFromFuture(WalletApi.addRecordWallet(type,id,value));
+        int recordHandle = TestHelper.getResultFromFuture(WalletApi.addRecordWallet(type,id,value, ""));
         int deleteRecordHandle = TestHelper.getResultFromFuture(WalletApi.deleteRecordWallet(type,id));
         assert (deleteRecordHandle != 0);
     }


### PR DESCRIPTION
Developed following APIs in LibVCX. Also, implemented these APIs in Java / iOS wrappers
* vcx_wallet_add_record_tags
* vcx_wallet_update_record_tags
* vcx_wallet_delete_record_tags
* vcx_wallet_open_search
* vcx_wallet_search_next_records
* vcx_wallet_close_search

Notes
* `addRecordWallet` in Java wrapper is updated to accept `tagsJson` param
* `addRecordWallet` in iOS wrapper is updated to accept `tagsJson` param
* `getRecordWallet` in iOS wrapper is updated to accept `optionsJson` param